### PR TITLE
Update Deactivate the management of M365 Apps through cloud update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # RealmJoin Remediation Scripts Changelog
 
+## 2026-05-12
+- Updated Deactivate the management of M365 Apps through cloud update
+
 ## 2026-04-25
 - Updated Enable Windows Location Service with end-user control & Automatic Time Zone Feature (Improved resilience when running during ESP; Improved Logging)
 - Updated Fix Duplicate ProfileList SIDs (Improved Logging)

--- a/m365-apps/deactivate-management-of-m365-apps-through-cloud-update/Remediate.ps1
+++ b/m365-apps/deactivate-management-of-m365-apps-through-cloud-update/Remediate.ps1
@@ -2,7 +2,8 @@
 #
 # Script Name:         Remediate.ps1
 # Description:         Detect if device is onboarded and locked to M365 Apps Cloud Update. If onboarded/locked, remediation starts and sets a registry key to offboard it.
-# Changelog:           2025-02-14: Improved handling to also support "choose your own" channel scenarios
+# Changelog:           2025-05-12: Added create of registry path if not exists to prevent remediation failure
+#                      2025-02-14: Improved handling to also support "choose your own" channel scenarios
 #                      2025-02-10: Initial version
 #
 #=============================================================================================================================
@@ -27,14 +28,14 @@ try {
 
     ## UpdatePath
     $keyNameUpdatePath = "updatepath"
-    $keyExistsUpdatePath = $null    
+    $keyExistsUpdatePath = $null
 
     # Functions
     Function Test-RegistryPath {
         param (
             [parameter(Mandatory=$true)][ValidateNotNullOrEmpty()]$Path
         )
-        
+
         try {
             Test-Path $Path -ErrorAction Stop | Out-Null
             return $true
@@ -48,7 +49,7 @@ try {
             [parameter(Mandatory=$true)][ValidateNotNullOrEmpty()]$Path,
             [parameter(Mandatory=$true)][ValidateNotNullOrEmpty()]$Key
         )
-        
+
         try {
             Get-ItemProperty -Path $Path -ErrorAction Stop | Select-Object -ExpandProperty $Key -ErrorAction Stop | Out-Null
             return $true
@@ -62,7 +63,7 @@ try {
             [parameter(Mandatory=$true)][ValidateNotNullOrEmpty()]$Path,
             [parameter(Mandatory=$true)][ValidateNotNullOrEmpty()]$Key
         )
-        
+
         try {
             $Value = Get-ItemPropertyValue -Path $Path -Name $Key -ErrorAction Stop
             return $Value
@@ -88,6 +89,9 @@ try {
         }
         if ($valueIsWrongIgnoreGPO) {
             Write-Host "Setting Key $keyNameIgnoreGPO to $desiredValueIgnoreGPO"
+            if (-not (Test-Path $cloudUpdatePath)) {
+                New-Item -Path $cloudUpdatePath -Force | Out-Null
+            }
             Set-ItemProperty -Path $cloudUpdatePath -Name $keyNameIgnoreGPO -Value $desiredValueIgnoreGPO -Type $keyTypeIgnoreGPO -Force
         }
 

--- a/m365-apps/deactivate-management-of-m365-apps-through-cloud-update/config.json
+++ b/m365-apps/deactivate-management-of-m365-apps-through-cloud-update/config.json
@@ -2,7 +2,7 @@
     "name": "Deactivate the management of M365 Apps through cloud update",
     "description": "Cloud Update (managed via the M365 Apps Admin Center) only supports Current Channel and Monthly Enterprise Channel. As soon as devices/users are onboarded to Cloud Update, they are locked and can't be moved to another channel as Cloud Update overwrites and ignores any policy/channel set via Intune or other means. To be able to move users/devices to another channel, they must be offboarded from cloud update. This remediation deactivates the management through cloud update by making sure the registry key IgnoreGPO has a value of zero. Assign this remediation to all your M365 Apps Update Channel entra groups as INCLUDE and also assign it as EXCLUDE to the M365 Apps Update Channel entra groups for Current Channel and Monthly Enterprise Channel.",
     "type": "DetectAndRemediate",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "runAsAccountType": "System",
     "enforceSignatureCheck": false,
     "runAs32Bit": false


### PR DESCRIPTION
This pull request updates the "Deactivate the management of M365 Apps through cloud update" remediation script to improve reliability. The main enhancement ensures that the required registry path is created if it does not exist before attempting to set a registry value, preventing remediation failures. Additionally, the script version and changelog have been updated to reflect this improvement.

**Remediation reliability improvements:**

* The `Remediate.ps1` script now checks if the registry path (`$cloudUpdatePath`) exists before setting the `IgnoreGPO` value. If the path does not exist, it is created to avoid remediation failures.

**Documentation and versioning updates:**

* Updated the changelog in `CHANGELOG.md` and in the script header to document the new behavior. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R5) [[2]](diffhunk://#diff-c531899d0570de0a5aca61f2e19248ed7857ff78ad2ff6d6d0a07847dfc49f5aL5-R6)
* Incremented the version in `config.json` from `1.0.0` to `1.1.0` to reflect the change.…prevent remediation failure